### PR TITLE
Error endpoint for REST API's now works, the import was wrong.

### DIFF
--- a/backend/src/controllers/error.ts
+++ b/backend/src/controllers/error.ts
@@ -7,10 +7,18 @@
 
 import { Request, Response, NextFunction } from "express";
 
-// Error controller
-export const Get404Page = (request : Request, response : Response, next : NextFunction) => {
+/**
+ * @name Handle404Response
+ * 
+ * @description Handle the 404 response for endpoints using REST API
+ * 
+ * @param request : Request
+ * @param response : Response
+ * @param next : NextFunction
+ */
+export const Handle404Response = (request : Request, response : Response, next : NextFunction) => {
 
     // Return a 404 response for a URL that doesn't exist
-    response.status(201).json({message : "Error 404: Page doesn't exist"});
+    response.status(201).json({message : "Error 404: This endpoint does not exist, please check your routing."});
 };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,7 +16,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from 'url';
 import feedRoutes from "./routes/feed.ts";
-import errorRoutes from "./routes/feed.ts";
+import errorRoutes from "./routes/error.ts";
 import socketRoutes from "./routes/socket.ts";
 import chatRoutes from "./routes/chat.ts";
 import { RequestInterface } from "./@types/index.ts";

--- a/backend/src/routes/error.ts
+++ b/backend/src/routes/error.ts
@@ -7,11 +7,11 @@
 
 import express from "express";
 
-import { Get404Page } from "../controllers/error.ts";
+import { Handle404Response } from "../controllers/error.ts";
 
 const errorRoutes = express.Router({ strict : true });
 
 // Handle our fallback router, this uses the * value
-errorRoutes.get("/f", Get404Page);
+errorRoutes.all("*", Handle404Response);
 
 export default errorRoutes;


### PR DESCRIPTION
Now the error endpoints for GraphQL and REST work as expected. REST returns a 404